### PR TITLE
Use jquery-less marionette and remove non-jquery globals

### DIFF
--- a/browserify/app.js
+++ b/browserify/app.js
@@ -1,6 +1,3 @@
-// add backbone.marionette into the window
-require("./marionette_shim")
-
 CatView   = require("./views/cat_view");
 
 var catView = new CatView({
@@ -8,3 +5,4 @@ var catView = new CatView({
 });
 
 catView.render();
+

--- a/browserify/index.html
+++ b/browserify/index.html
@@ -1,4 +1,5 @@
 <html>
   <body></body>
+  <script src="node_modules/jquery/dist/jquery.js"></script>
   <script src="build.js"></script>
 </html>

--- a/browserify/marionette_shim.js
+++ b/browserify/marionette_shim.js
@@ -1,4 +1,2 @@
-Backbone    = require('backbone');
-Backbone.$  = require('jquery');
-_           = require('underscore');
-require('backbone.marionette');
+require('backbone').$ = $ || jQuery
+

--- a/browserify/package.json
+++ b/browserify/package.json
@@ -1,13 +1,12 @@
 {
   "name": "marionette-browserify",
   "scripts": {
-    "build": "./node_modules/browserify/bin/cmd.js app.js -o build.js"
+    "build": "./node_modules/browserify/bin/cmd.js marionette_shim.js app.js -o build.js"
   },
   "dependencies": {
-    "backbone.marionette": "~1.6.3",
-    "backbone": "~1.1.2",
     "underscore": "~1.6.0",
-    "jquery": "~2.1.0"
+    "jquery": "^2.1.0",
+    "backbone.marionette": "git://github.com/bonobos/backbone.marionette#fix/remove-jquery-dep"
   },
   "devDependencies": {
     "browserify": "~3.31.2"

--- a/browserify/views/cat_view.js
+++ b/browserify/views/cat_view.js
@@ -1,3 +1,7 @@
-module.exports = Backbone.Marionette.ItemView.extend({
+_ = require('underscore')
+Marionette = require('backbone.marionette')
+
+module.exports = Marionette.ItemView.extend({
   template: _.template("<h2>i am the cat man</h2>")
 });
+


### PR DESCRIPTION
Gives an example of using Marionette with browserify without jquery in marionette's package.json. Uses a global $/jQuery though something like [browserify-shim](https://github.com/thlorenz/browserify-shim) can be used.

Also removes everything but jQuery from the global scope in this example.
