### PR TITLE
Remove modulesDirectories property

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -47,7 +47,6 @@ module.exports = {
     })
   ],
   resolve: {
-    modulesDirectories: [path.join(__dirname, './node_modules')],
     root: path.join(__dirname, './app')
   },
   resolveLoader: {


### PR DESCRIPTION
`node_modules` folder used by default, but specifying `path.join` command causes the error when build under Node 4.x and NPM 2.x