### PR TITLE
use webpack-dev-server for dev experience

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -28,7 +28,7 @@ module.exports =  {
     var sourceRoot = this.sourceRoot();
     var source = this.getSourcePath(sourceRoot, option);
     var destination = this.destinationRoot(option);
-    
     this.fs.copy(source, destination, { globOptions: { dot: true } });
+    this.directory('./', destination);
   }
 };

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 var generators = require('yeoman-generator');
 var Helpers = require('./helpers');
 var boilerplates = [
+  "webpack",
   "browserify",
   "browserify-gulp",
   "browserify-grunt",

--- a/app/templates/.editorconfig
+++ b/app/templates/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/test.js
+++ b/app/test.js
@@ -10,6 +10,7 @@ var boilerplates = [
   'foo', 'bar'
 ];
 var expectedFiles = [
+  '.editorconfig',
   '.eslintrc',
   '.gitignore',
   'Makefile',

--- a/webpack/Makefile
+++ b/webpack/Makefile
@@ -1,11 +1,9 @@
 MODULESDIR = ./node_modules/.bin
-build:
-	$(MODULESDIR)/webpack
+build: clean
+	$(MODULESDIR)/webpack -p
 
-server:
-	$(MODULESDIR)/http-server
-
-start: build server
+start:
+	$(MODULESDIR)/webpack-dev-server
 
 clean:
 	@rm -rf public

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -8,8 +8,10 @@
     "url": ""
   },
   "scripts": {
-    "start": "make start",
-    "build": "eslint app && make build",
+    "start": "webpack-dev-server",
+    "prebuild": "rm -rf ./public/",
+    "build": "npm run lint && webpack -p",
+    "lint": "eslint app",
     "test": "echo test"
   },
   "dependencies": {
@@ -26,10 +28,11 @@
     "css-loader": "^0.23.1",
     "eslint": "^2.11.1",
     "extract-text-webpack-plugin": "^1.0.1",
-    "http-server": "^0.9.0",
     "stylus": "^0.54.5",
     "style-loader": "^0.13.1",
     "underscore-template-loader": "^0.7.2",
-    "webpack": "^1.12.15"
+    "webpack": "^1.12.15",
+    "webpack-dev-server": "^1.16.2",
+    "webpack-merge": "^0.15.0"
   }
 }

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -4,8 +4,9 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
+const merge = require('webpack-merge');
 
-module.exports = {
+const webpackCommon = {
   entry: {
     app: ['./app/initialize']
   },
@@ -33,7 +34,7 @@ module.exports = {
   output: {
     filename: 'app.js',
     path: path.join(__dirname, './public'),
-    publicPath: '/public'
+    publicPath: '/public/'
   },
   plugins: [
     new ExtractTextPlugin('app.css'),
@@ -53,3 +54,20 @@ module.exports = {
     root: path.join(__dirname, './node_modules')
   }
 };
+
+switch (process.env.npm_lifecycle_event) {
+  case 'start':
+  case 'dev':
+    module.exports = merge(webpackCommon, {
+      devtool: '#inline-source-map',
+      devServer: {
+        inline: true
+      }
+    });
+    break;
+  default:
+    module.exports = merge(webpackCommon, {
+      devtool: 'source-map'
+    });
+    break;
+}


### PR DESCRIPTION
- Added `webpack-dev-server` which brings in live-reload feature
- Removed `http-server` dep
- Added `.editorconfig`
- Changed to use npm scripts only (removed `Makefile`)
