### PR TITLE
Remove deprecation warning

### DIFF
--- a/webpack2/webpack.config.js
+++ b/webpack2/webpack.config.js
@@ -17,10 +17,7 @@ const webpackCommon = {
         exclude: /node_modules/,
         use: [
           {
-            loader: 'babel-loader',
-            options: {
-              presets: ['es2015']
-            }
+            loader: 'babel-loader?presets[]=es2015'
           }
         ]
       },
@@ -34,8 +31,8 @@ const webpackCommon = {
         test: /\.css$/,
         exclude: /node_modules/,
         use: ExtractTextPlugin.extract({
-          fallbackLoader: 'style-loader',
-          loader: 'css-loader'
+          fallback: 'style-loader',
+          use: 'css-loader'
         })
       }
     ]


### PR DESCRIPTION
When run build **loader-utils** issued this deprecation message:
```
loader option has been deprecated - replace with "use"
(node:22316) DeprecationWarning: loaderUtils.parseQuery() received a non-string
value which can be problematic
```
So based on **loader-utils** (See: https://github.com/webpack/loader-utils/issues/56)  and **babel-loader** (See: https://github.com/babel/babel-loader#options) documentation.  **options** have been removed as object and used query string instead.

Updated **fallbackLoader** to **fallback**
Updated **loader** to **use**